### PR TITLE
Add markdown support

### DIFF
--- a/app/assets/stylesheets/base/globals.scss
+++ b/app/assets/stylesheets/base/globals.scss
@@ -147,3 +147,18 @@ div.invalid-instance {
   }
 }
 
+.markdown {
+  &.short-description {
+    overflow: hidden;
+
+    > * {
+      overflow: hidden;
+      white-space: nowrap;
+      text-overflow: ellipsis;
+
+      &:not(:first-child) {
+        display: none;
+      }
+    }
+  }
+}

--- a/app/javascript/packs/common/markdown.js
+++ b/app/javascript/packs/common/markdown.js
@@ -1,0 +1,13 @@
+import Vue from 'vue/dist/vue.esm'
+import VueMarkdown from 'vue-markdown'
+
+document.addEventListener('DOMContentLoaded', () => {
+  Array.from(document.querySelectorAll('.markdown')).forEach(markdown => {
+    new Vue({
+      el: markdown,
+      components: {
+        'vue-markdown': VueMarkdown
+      }
+    });
+  })
+});

--- a/app/javascript/packs/resource/index.js
+++ b/app/javascript/packs/resource/index.js
@@ -1,6 +1,7 @@
 import 'core-js/fn/promise/finally';
 
 import Vue from 'vue/dist/vue.esm'
+import VueMarkdown from 'vue-markdown'
 
 import Store from './store.js';
 import FilterAttributesComponent from './ps-filter-attributes.vue';
@@ -16,6 +17,7 @@ document.addEventListener('DOMContentLoaded', () => {
       'ps-filter-attributes': FilterAttributesComponent,
       'ps-attributes': AttributesComponent,
       'ps-code-buttons': CodeButtonsComponent,
+      'vue-markdown': VueMarkdown,
     },
     methods: {
       onCancelClick: function() {

--- a/app/javascript/packs/resource/ps-attribute.vue
+++ b/app/javascript/packs/resource/ps-attribute.vue
@@ -59,7 +59,8 @@
       dd {{attribute.maxItems}}
     .constraint-cell.description(v-if='attribute.description')
       dt Description
-      dd {{attribute.description}}
+      dd
+        vue-markdown(class='markdown', :source='attribute.description')
   .contraints-row.collapse(:id="'collapse-representation-' + attribute.id"
     v-if='manageMode && activeAttributeRepresentation'
   )
@@ -81,6 +82,7 @@
 
 <script>
 import vSelect from 'vue-select';
+import VueMarkdown from 'vue-markdown'
 import Store from './store.js';
 
 export default {
@@ -163,7 +165,7 @@ export default {
       return name;
     }
   },
-  components: {'v-select': vSelect}
+  components: {'v-select': vSelect, 'vue-markdown': VueMarkdown}
 }
 </script>
 

--- a/app/javascript/packs/resources/ps-resource.vue
+++ b/app/javascript/packs/resources/ps-resource.vue
@@ -5,9 +5,11 @@ div(style='margin-top: -1px;')
     :href='resourcePath'
   )
     .flexcontainer-space-between
-      .name(v-html='displayedResourceName')
-      .error(v-if='resource.hasInvalidMocks')
+      .name(style='flex-basis: 200px', v-html='displayedResourceName')
+      vue-markdown(class='markdown short-description', style='flex: 1', :source='displayedResourceDescription')
+      .error(style='flex-basis: 50px')
         .tool-tip(
+          v-if='resource.hasInvalidMocks'
           data-toggle="tooltip"
           data-placement="top"
           title="Invalid mocks !"
@@ -25,6 +27,7 @@ div(style='margin-top: -1px;')
 </template>
 
 <script>
+import VueMarkdown from 'vue-markdown'
 import Store from './store.js';
 
 export default {
@@ -65,6 +68,9 @@ export default {
 
       return indentation + this.highlightedName;
     },
+    displayedResourceDescription: function() {
+      return this.resource.description;
+    },
     shouldDisplayChildren: function() {
       if (this.treeMode) {
         return this.depth < 10
@@ -101,7 +107,8 @@ export default {
       return newName;
     }
   },
-  name: 'ps-resource'
+  name: 'ps-resource',
+  components: {'vue-markdown': VueMarkdown}
 }
 </script>
 

--- a/app/javascript/packs/resources/store.js
+++ b/app/javascript/packs/resources/store.js
@@ -26,6 +26,7 @@ export default {
       return {
         id: r.id,
         name: r.name,
+        description: r.description,
         usedResources: r.used_resources,
         hasInvalidMocks: r['has_invalid_mocks?'],
         requestRouteIds: r.request_route_ids,

--- a/app/serializers/resource_index_serializer.rb
+++ b/app/serializers/resource_index_serializer.rb
@@ -1,5 +1,5 @@
 class ResourceIndexSerializer < ActiveModel::Serializer
-  attributes :id, :name, :has_invalid_mocks?
+  attributes :id, :name, :description, :has_invalid_mocks?
   attributes :request_route_ids
   attributes :response_ids
   has_many :used_resources, serializer: IdSerializer

--- a/app/views/projects/show.html.haml
+++ b/app/views/projects/show.html.haml
@@ -1,4 +1,6 @@
 = content_for :title, "Project #{project.title}"
+- content_for :page_scripts do
+  = javascript_pack_tag("common/markdown.js")
 
 #project-show
   %h1= project.title
@@ -11,8 +13,7 @@
   %p= project.member_list
 
   %h4 Description
-  %p
-    = simple_format(project.description)
+  %vue-markdown{class: 'markdown'}= project.description
 
   - unless project.proxy_configuration&.target_base_url.blank?
 

--- a/app/views/query_parameters/_query_parameter.html.haml
+++ b/app/views/query_parameters/_query_parameter.html.haml
@@ -19,4 +19,5 @@
         .col-xs-4
           %dl
             %dt Description
-            %dd= simple_format(query_parameter.description)
+            %dd{class: 'markdown'}
+              %vue-markdown= query_parameter.description

--- a/app/views/resources/show.html.haml
+++ b/app/views/resources/show.html.haml
@@ -37,8 +37,7 @@
         .btn.btn-default.h-margin{'@click': 'onCancelClick', 'v-if': 'manageMode'} Cancel
       %transition{name: "w-slide-fade"}
         .btn.btn-primary{'@click': 'onUpdateClick', 'v-if': 'manageMode'} Update
-  %p
-    = simple_format(resource.description)
+  %vue-markdown{class: 'markdown'}= resource.description
   - unless resource.used_in_resources.empty?
     %p
       Used in:&nbsp

--- a/app/views/routes/_route_summary.html.haml
+++ b/app/views/routes/_route_summary.html.haml
@@ -13,7 +13,8 @@
       .col-xs-3
         %dl
           %dt Description
-          %dd{'v-pre': true}= simple_format(route.description)
+          %dd{class: 'markdown'}
+            %vue-markdown= route.description
       .col-xs-3
         - if should_display_representations && !route.resource_representations.empty?
           %dl

--- a/app/views/routes/index.html.haml
+++ b/app/views/routes/index.html.haml
@@ -1,4 +1,6 @@
 = content_for :title, "Routes"
+- content_for :page_scripts do
+  = javascript_pack_tag("common/markdown.js")
 
 .flexspace-and-center
   %h1 Routes
@@ -13,13 +15,16 @@
     .routes-sub-container
       - @routes_by_resource[resource].sort_by { |route| [route.url, route.http_method_order] }.each do |route|
         %a{class: 'route-row', href: project_route_path(project, route)}
-          %div{style: 'width: 10%'}
+          %div{style: 'flex-basis: 100px'}
             %span{ class: label_class_for_http_method(route.http_method) }= route.http_method
-          %div{style: 'flex: 1'}= route.url
-          %div{style: 'width: 25%'}= route.resource_representations.uniq.map(&:name).join(", ")
+          %div{style: 'flex-basis: 250px'}= route.url
+          %vue-markdown{class: 'markdown short-description', style: 'flex: 1'}= route.description
+          %div{style: 'flex-basis: 250px'}= route.resource_representations.uniq.map(&:name).join(", ")
           - if route.responses.empty?
-            %div.tool-tip{style: 'width: 25%', 'data-toggle' => "tooltip", 'data-placement' => "top", title: "No responses"}
+            %div.tool-tip{style: 'flex-basis: 50px', 'data-toggle' => "tooltip", 'data-placement' => "top", title: "No responses"}
               \/!\
+          - else
+            %div{style: 'flex-basis: 50px'}
 
 - else
   %p

--- a/app/views/routes/show.html.haml
+++ b/app/views/routes/show.html.haml
@@ -4,6 +4,7 @@
   = javascript_include_tag("validate_instance")
   = javascript_include_tag("generate_instance")
   = javascript_include_tag("routes/show")
+  = javascript_pack_tag("common/markdown.js")
 
 .row
   .col-xs-12

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "underscore": "^1.8.3",
     "vue": "^2.5.13",
     "vue-loader": "^13.7.0",
+    "vue-markdown": "^2.2.4",
     "vue-select": "^2.4.0",
     "vue-svg-loader": "^0.5.0",
     "vue-template-compiler": "^2.5.13"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1247,6 +1247,11 @@ clone@^1.0.2:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/clone/-/clone-1.0.4.tgz#da309cc263df15994c688ca902179ca3c7cd7c7e"
 
+clone@^2.1.0:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/clone/-/clone-2.1.2.tgz#1b7f4b9f591f1e8f83670401600345a02887435f"
+  integrity sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=
+
 co@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/co/-/co-4.6.0.tgz#6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184"
@@ -2688,6 +2693,11 @@ he@^1.1.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
 
+highlight.js@^9.12.0:
+  version "9.15.9"
+  resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-9.15.9.tgz#865257da1dbb4a58c4552d46c4b3854f77f0e6d5"
+  integrity sha512-M0zZvfLr5p0keDMCAhNBp03XJbKBxUx5AfyfufMdFMEP4N/Xj6dh0IqC75ys7BAzceR34NgcvXjupRVaHBPPVQ==
+
 hmac-drbg@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/hmac-drbg/-/hmac-drbg-1.0.1.tgz#d2745701025a6c775a6c545793ed502fc0c649a1"
@@ -3286,6 +3296,13 @@ jstransformer@1.0.0:
     is-promise "^2.0.0"
     promise "^7.0.1"
 
+katex@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/katex/-/katex-0.6.0.tgz#12418e09121c05c92041b6b3b9fb6bab213cb6f3"
+  integrity sha1-EkGOCRIcBckgQbazuftrqyE8tvM=
+  dependencies:
+    match-at "^0.1.0"
+
 killable@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/killable/-/killable-1.0.1.tgz#4c8ce441187a061c7474fb87ca08e2a638194892"
@@ -3340,6 +3357,13 @@ levn@~0.3.0:
   dependencies:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
+
+linkify-it@~1.2.2:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/linkify-it/-/linkify-it-1.2.4.tgz#0773526c317c8fd13bd534ee1d180ff88abf881a"
+  integrity sha1-B3NSbDF8j9E71TTuHRgP+Iq/iBo=
+  dependencies:
+    uc.micro "^1.0.1"
 
 load-json-file@^1.0.0:
   version "1.1.0"
@@ -3483,6 +3507,82 @@ map-visit@^1.0.0:
   dependencies:
     object-visit "^1.0.0"
 
+markdown-it-abbr@^1.0.3:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/markdown-it-abbr/-/markdown-it-abbr-1.0.4.tgz#d66b5364521cbb3dd8aa59dadfba2fb6865c8fd8"
+  integrity sha1-1mtTZFIcuz3Yqlna37ovtoZcj9g=
+
+markdown-it-deflist@^2.0.1:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/markdown-it-deflist/-/markdown-it-deflist-2.0.3.tgz#5727db04184d3cb2bc6ee4a9641e3a1091d5fd6f"
+  integrity sha512-/BNZ8ksW42bflm1qQLnRI09oqU2847Z7MVavrR0MORyKLtiUYOMpwtlAfMSZAQU9UCvaUZMpgVAqoS3vpToJxw==
+
+markdown-it-emoji@^1.1.1:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/markdown-it-emoji/-/markdown-it-emoji-1.4.0.tgz#9bee0e9a990a963ba96df6980c4fddb05dfb4dcc"
+  integrity sha1-m+4OmpkKljupbfaYDE/dsF37Tcw=
+
+markdown-it-footnote@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/markdown-it-footnote/-/markdown-it-footnote-2.0.0.tgz#14e9c4f68ff12cf354fa365ae378276e8104ca94"
+  integrity sha1-FOnE9o/xLPNU+jZa43gnboEEypQ=
+
+markdown-it-ins@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/markdown-it-ins/-/markdown-it-ins-2.0.0.tgz#a5aa6a30f1e2f71e9497567cfdff40f1fde67483"
+  integrity sha1-papqMPHi9x6Ul1Z8/f9A8f3mdIM=
+
+markdown-it-katex@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/markdown-it-katex/-/markdown-it-katex-2.0.3.tgz#d7b86a1aea0b9d6496fab4e7919a18fdef589c39"
+  integrity sha1-17hqGuoLnWSW+rTnkZoY/e9YnDk=
+  dependencies:
+    katex "^0.6.0"
+
+markdown-it-mark@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/markdown-it-mark/-/markdown-it-mark-2.0.0.tgz#46a1aa947105aed8188978e0a016179e404f42c7"
+  integrity sha1-RqGqlHEFrtgYiXjgoBYXnkBPQsc=
+
+markdown-it-sub@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/markdown-it-sub/-/markdown-it-sub-1.0.0.tgz#375fd6026eae7ddcb012497f6411195ea1e3afe8"
+  integrity sha1-N1/WAm6ufdywEkl/ZBEZXqHjr+g=
+
+markdown-it-sup@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/markdown-it-sup/-/markdown-it-sup-1.0.0.tgz#cb9c9ff91a5255ac08f3fd3d63286e15df0a1fc3"
+  integrity sha1-y5yf+RpSVawI8/09YyhuFd8KH8M=
+
+markdown-it-task-lists@^2.0.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/markdown-it-task-lists/-/markdown-it-task-lists-2.1.1.tgz#f68f4d2ac2bad5a2c373ba93081a1a6848417088"
+  integrity sha512-TxFAc76Jnhb2OUu+n3yz9RMu4CwGfaT788br6HhEDlvWfdeJcLUsxk1Hgw2yJio0OXsxv7pyIPmvECY7bMbluA==
+
+markdown-it-toc-and-anchor@^4.1.2:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/markdown-it-toc-and-anchor/-/markdown-it-toc-and-anchor-4.2.0.tgz#d1613327cc63c61f82cd66cbac5564f4db12c0e9"
+  integrity sha512-DusSbKtg8CwZ92ztN7bOojDpP4h0+w7BVOPuA3PHDIaabMsERYpwsazLYSP/UlKedoQjOz21mwlai36TQ04EpA==
+  dependencies:
+    clone "^2.1.0"
+    uslug "^1.0.4"
+
+markdown-it@^6.0.1:
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/markdown-it/-/markdown-it-6.1.1.tgz#ced037f4473ee9f5153ac414f77dc83c91ba927c"
+  integrity sha1-ztA39Ec+6fUVOsQU933IPJG6knw=
+  dependencies:
+    argparse "^1.0.7"
+    entities "~1.1.1"
+    linkify-it "~1.2.2"
+    mdurl "~1.0.1"
+    uc.micro "^1.0.1"
+
+match-at@^0.1.0:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/match-at/-/match-at-0.1.1.tgz#25d040d291777704d5e6556bbb79230ec2de0540"
+  integrity sha512-h4Yd392z9mST+dzc+yjuybOGFNOZjmXIPKWjxBd1Bb23r4SmDOsk2NYCU2BMUBGbSpZqwVsZYNq26QS3xfaT3Q==
+
 math-expression-evaluator@^1.2.14:
   version "1.2.17"
   resolved "https://registry.yarnpkg.com/math-expression-evaluator/-/math-expression-evaluator-1.2.17.tgz#de819fdbcd84dccd8fae59c6aeb79615b9d266ac"
@@ -3502,6 +3602,11 @@ md5.js@^1.3.4:
 mdn-data@~1.1.0:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/mdn-data/-/mdn-data-1.1.4.tgz#50b5d4ffc4575276573c4eedb8780812a8419f01"
+
+mdurl@~1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/mdurl/-/mdurl-1.0.1.tgz#fe85b2ec75a59037f2adfec100fd6c601761152e"
+  integrity sha1-/oWy7HWlkDfyrf7BAP1sYBdhFS4=
 
 media-typer@0.3.0:
   version "0.3.0"
@@ -5998,6 +6103,11 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
+uc.micro@^1.0.1:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/uc.micro/-/uc.micro-1.0.6.tgz#9c411a802a409a91fc6cf74081baba34b24499ac"
+  integrity sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==
+
 uglify-es@^3.3.4:
   version "3.3.9"
   resolved "https://registry.yarnpkg.com/uglify-es/-/uglify-es-3.3.9.tgz#0c1c4f0700bed8dbc124cdb304d2592ca203e677"
@@ -6084,6 +6194,11 @@ units-css@^0.4.0:
     isnumeric "^0.2.0"
     viewport-dimensions "^0.2.0"
 
+"unorm@>= 1.0.0":
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/unorm/-/unorm-1.6.0.tgz#029b289661fba714f1a9af439eb51d9b16c205af"
+  integrity sha512-b2/KCUlYZUeA7JFUuRJZPUtr4gZvBh7tavtv4fvk4+KV9pfGiR6CQAQAWl49ZpR3ts2dk4FYkP7EIgDJoiOLDA==
+
 unpipe@1.0.0, unpipe@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/unpipe/-/unpipe-1.0.0.tgz#b2bf4ee8514aae6165b4817829d21b2ef49904ec"
@@ -6130,6 +6245,13 @@ url@^0.11.0:
 use@^3.1.0:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/use/-/use-3.1.1.tgz#d50c8cac79a19fbc20f2911f56eb973f4e10070f"
+
+uslug@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/uslug/-/uslug-1.0.4.tgz#b9a22f0914e0a86140633dacc302e5f4fa450677"
+  integrity sha1-uaIvCRTgqGFAYz2swwLl9PpFBnc=
+  dependencies:
+    unorm ">= 1.0.0"
 
 util-deprecate@~1.0.1:
   version "1.0.2"
@@ -6220,6 +6342,25 @@ vue-loader@^13.7.0:
     vue-hot-reload-api "^2.2.0"
     vue-style-loader "^3.0.0"
     vue-template-es2015-compiler "^1.6.0"
+
+vue-markdown@^2.2.4:
+  version "2.2.4"
+  resolved "https://registry.yarnpkg.com/vue-markdown/-/vue-markdown-2.2.4.tgz#db0f774178f3bc91ee18c626d86a3a0d2de22746"
+  integrity sha512-hoTX/W1UIdHZrp/b0vpHSsJXAEfWsafaQLgtE2VX4gY8O/C3L2Gabqu95gyG429rL4ML1SwGv+xsPABX7yfFIQ==
+  dependencies:
+    highlight.js "^9.12.0"
+    markdown-it "^6.0.1"
+    markdown-it-abbr "^1.0.3"
+    markdown-it-deflist "^2.0.1"
+    markdown-it-emoji "^1.1.1"
+    markdown-it-footnote "^2.0.0"
+    markdown-it-ins "^2.0.0"
+    markdown-it-katex "^2.0.3"
+    markdown-it-mark "^2.0.0"
+    markdown-it-sub "^1.0.0"
+    markdown-it-sup "^1.0.0"
+    markdown-it-task-lists "^2.0.1"
+    markdown-it-toc-and-anchor "^4.1.2"
 
 vue-select@^2.4.0:
   version "2.5.1"


### PR DESCRIPTION
Add markdown support to improve description rendering.
We often want to add styles in descriptions but currently only text was accepted.
For some case, it was really not enough for everyday use cases.

Also, we add a short description in list views so users can quickly understand what the element (route, resource) is about.
It means changing a little the styles to have something more like a table.

This commit does the following:

* Add `vue-markdown`
* Inject it into `project`, `routes` and `resources` pages where needed
* Add styles for markdown for normal and short description
* Add `Resource.description` when listing all project resources

# QA

<details>
<summary>Screenshot and scenarios</summary>

## Project view

![image](https://user-images.githubusercontent.com/11132978/62835461-262b6480-bc59-11e9-946a-03f6331ce59e.png)

## Resources list

![image](https://user-images.githubusercontent.com/11132978/62835522-c71a1f80-bc59-11e9-8627-c0546878b3d0.png)

## Resource detail

![image](https://user-images.githubusercontent.com/11132978/62835541-fd579f00-bc59-11e9-9cbe-a51df7237c97.png)

## Resource detail with attribute description

![image](https://user-images.githubusercontent.com/11132978/62835537-ed3fbf80-bc59-11e9-99c4-fc3a8aafbed2.png)

## Route list

![image](https://user-images.githubusercontent.com/11132978/62835497-94702700-bc59-11e9-9a8b-0bbc324cdf8f.png)

## Route detail

![image](https://user-images.githubusercontent.com/11132978/62835506-a05be900-bc59-11e9-8e26-61ad73b027f7.png)

## Route detail with query parameter

![image](https://user-images.githubusercontent.com/11132978/62835517-b5d11300-bc59-11e9-86f0-800d41760dbe.png)

</details>