### PR TITLE
Add a title on representation circles

### DIFF
--- a/app/javascript/packs/resource/ps-attribute.vue
+++ b/app/javascript/packs/resource/ps-attribute.vue
@@ -22,6 +22,7 @@
         v-if='r.hasAttribute || manageMode'
         :class="[{selected: r.hasAttribute, hoverable: manageMode}, r.colorClass]"
         @click='toggleBelongingAttribute(attribute.id, r.id)'
+        :title='representationName(r.id)'
       )
     .cell
       a(
@@ -84,7 +85,7 @@ import vSelect from 'vue-select';
 import Store from './store.js';
 
 export default {
-  props: ['attribute', 'manageMode', 'activeRepresentation'],
+  props: ['attribute', 'manageMode', 'activeRepresentation', 'representations'],
   methods: {
     toggleBelongingAttribute: function(attributeId, representationId) {
         if(!this.manageMode)
@@ -99,6 +100,10 @@ export default {
         url += '#rep-' + this.activeAttributeRepresentation.selectedRepresentationId
       }
       return url;
+    },
+    representationName: function(representationId) {
+      let representation = this.representations.find(r => r.id === representationId)
+      return representation !== undefined ? representation.name : ''
     }
   },
   computed: {

--- a/app/javascript/packs/resource/ps-attributes.vue
+++ b/app/javascript/packs/resource/ps-attributes.vue
@@ -30,6 +30,7 @@
     :attribute='a'
     :manage-mode='manageMode'
     :active-representation='activeRepresentation'
+    :representations='representations'
   )
   .no-attributes(v-if='attributes.length === 0').
     There is no attributes in this resource, you can add some
@@ -44,7 +45,7 @@ import Store from './store.js';
 import AttributeComponent from './ps-attribute.vue';
 
 export default {
-  props: ['attributes', 'manageMode', 'activeRepresentation', 'sortMode', 'searchQuery'],
+  props: ['attributes', 'manageMode', 'activeRepresentation', 'sortMode', 'searchQuery', 'representations'],
   methods: {
     onClickExpandAll: function() {
       $('.contraints-row').collapse('show');

--- a/app/views/resources/_attributes.html.haml
+++ b/app/views/resources/_attributes.html.haml
@@ -11,4 +11,4 @@
 
 %ps-attributes{':attributes': 'resource.attributes', ':manage-mode': 'manageMode',
   ':active-representation': 'activeRepresentation', ':sort-mode': 'sortMode',
-  ':search-query': 'searchQuery'}
+  ':search-query': 'searchQuery', ':representations': 'resource.representations'}


### PR DESCRIPTION
It is quite complex to differentiate representation with only the color.
To simplify this, add a title on the circle to help the user.

This commit does the following:

* Add title on representation circles
* Bubble up required changes

# QA

<details>
<summary>Screenshots</summary>

![qa](https://user-images.githubusercontent.com/11132978/62837689-84187600-bc72-11e9-9254-6b95674c4051.gif)

</details>