### PR TITLE
Add API Gateway integration

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -19,6 +19,9 @@ class ProjectsController < ApplicationController
       format.swagger do
         render json: Swagger::ProjectDecorator.new(project).to_swagger, content_type: 'application/json'
       end
+      format.api_gateway_integration do
+        render json: Swagger::ProjectDecorator.new(project).to_swagger(true), content_type: 'application/json'
+      end
       %i[swift kotlin ruby typescript].each do |language|
         format.send(language) do
           send_data(
@@ -35,6 +38,7 @@ class ProjectsController < ApplicationController
 
   def edit
     project.build_proxy_configuration unless project.proxy_configuration
+    project.build_api_gateway_integration unless project.api_gateway_integration
   end
 
   def create

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -17,10 +17,8 @@ class ProjectsController < ApplicationController
         )
       end
       format.swagger do
-        render json: Swagger::ProjectDecorator.new(project).to_swagger, content_type: 'application/json'
-      end
-      format.api_gateway_integration do
-        render json: Swagger::ProjectDecorator.new(project).to_swagger(true), content_type: 'application/json'
+        swagger = Swagger::ProjectDecorator.new(project).to_swagger(with_api_gateway_integration: params[:with_api_gateway_integration])
+        render json: swagger, content_type: 'application/json'
       end
       %i[swift kotlin ruby typescript].each do |language|
         format.send(language) do

--- a/app/decorators/swagger/project_decorator.rb
+++ b/app/decorators/swagger/project_decorator.rb
@@ -18,7 +18,7 @@ module Swagger
     end
 
     def info_title(with_api_gateway_integration)
-      return title unless with_api_gateway_integration && api_gateway_integration.title.present?
+      return title unless with_api_gateway_integration && api_gateway_integration&.title.present?
       api_gateway_integration.title
     end
 

--- a/app/decorators/swagger/project_decorator.rb
+++ b/app/decorators/swagger/project_decorator.rb
@@ -2,7 +2,7 @@ module Swagger
   class ProjectDecorator < Draper::Decorator
     delegate_all
 
-    def to_swagger(with_api_gateway_integration = false)
+    def to_swagger(with_api_gateway_integration: false)
       {
         openapi: '3.0.0',
         info: {
@@ -18,11 +18,8 @@ module Swagger
     end
 
     def info_title(with_api_gateway_integration)
-      if with_api_gateway_integration && !api_gateway_integration.title.to_s.strip.empty?
-        api_gateway_integration.title
-      else
-        title
-      end
+      return title unless with_api_gateway_integration && api_gateway_integration.title.present?
+      api_gateway_integration.title
     end
 
     def components

--- a/app/decorators/swagger/route_decorator.rb
+++ b/app/decorators/swagger/route_decorator.rb
@@ -97,7 +97,7 @@ class Swagger::RouteDecorator < Draper::Decorator
       requestParameters: request_parameters,
       timeoutInMillis: api_gateway_integration.timeout_in_millis,
       type: 'http_proxy',
-      uri: api_gateway_integration.uri_prefix + normalized_url
+      uri: api_gateway_integration.uri_prefix + normalized_url(remove_plus_signs: true)
     }
   end
 
@@ -107,15 +107,23 @@ class Swagger::RouteDecorator < Draper::Decorator
       part.starts_with?(':')
     end
     parameter_parts.map do |part|
-      part[1..-1]
+      if part.ends_with?('+')
+        part[1..-2]
+      else
+        part[1..-1]
+      end
     end
   end
 
-  def normalized_url
+  def normalized_url(remove_plus_signs: false)
     parts = url.split('/')
     normalized_parts = parts.map do |part|
       if part.starts_with?(':')
-        '{' + part[1..-1] + '}'
+        if remove_plus_signs && part.ends_with?('+')
+          '{' + part[1..-2] + '}'
+        else
+          '{' + part[1..-1] + '}'
+        end
       else
         part
       end

--- a/app/decorators/swagger/route_decorator.rb
+++ b/app/decorators/swagger/route_decorator.rb
@@ -72,19 +72,13 @@ class Swagger::RouteDecorator < Draper::Decorator
   def x_amazon_apigateway_integration(api_gateway_integration)
     return unless api_gateway_integration
 
-    parameters = path_parameters
-
-    cache_key_parameters = parameters.map do |parameter|
-      'integration.request.path.' + parameter
-    end
-
     request_parameters = {}
-    parameters.each do |parameter|
+    path_parameters.each do |parameter|
       request_parameters['integration.request.path.' + parameter] = 'method.request.path.' + parameter
     end
 
     {
-      cacheKeyParameters: cache_key_parameters,
+      cacheKeyParameters: request_parameters.keys,
       httpMethod: http_method,
       passthroughBehavior: 'when_no_match',
       requestParameters: request_parameters,

--- a/app/decorators/swagger/route_decorator.rb
+++ b/app/decorators/swagger/route_decorator.rb
@@ -116,18 +116,10 @@ class Swagger::RouteDecorator < Draper::Decorator
   end
 
   def normalized_url(remove_plus_signs: false)
-    parts = url.split('/')
-    normalized_parts = parts.map do |part|
-      if part.starts_with?(':')
-        if remove_plus_signs && part.ends_with?('+')
-          '{' + part[1..-2] + '}'
-        else
-          '{' + part[1..-1] + '}'
-        end
-      else
-        part
-      end
+    path_parameters_names.inject(url) do |url, parameter_name|
+      pattern = /:(#{parameter_name}\+?)/
+      replacement = remove_plus_signs ? "{#{parameter_name}}" : '{\1}'
+      url.gsub(pattern, replacement)
     end
-    normalized_parts.join('/')
   end
 end

--- a/app/models/api_gateway_integration.rb
+++ b/app/models/api_gateway_integration.rb
@@ -1,0 +1,7 @@
+class ApiGatewayIntegration < ApplicationRecord
+  belongs_to :project
+
+  validates :title, presence: false
+  validates :uri_prefix, presence: false
+  validates :timeout_in_millis, presence: false
+end

--- a/app/models/api_gateway_integration.rb
+++ b/app/models/api_gateway_integration.rb
@@ -1,7 +1,3 @@
 class ApiGatewayIntegration < ApplicationRecord
   belongs_to :project
-
-  validates :title, presence: false
-  validates :uri_prefix, presence: false
-  validates :timeout_in_millis, presence: false
 end

--- a/app/models/metadatum.rb
+++ b/app/models/metadatum.rb
@@ -14,15 +14,9 @@ class Metadatum < ApplicationRecord
 
   def json_schema
     if datetime? || date?
-      non_nullable = { type: :string, format: primitive_type }
+      { type: :string, format: primitive_type, nullable: nullable }
     else
-      non_nullable = { type: primitive_type }
-    end
-
-    if nullable
-      { oneOf: [non_nullable, { type: 'null' }] }
-    else
-      non_nullable
+      { type: primitive_type, nullable: nullable }
     end
   end
 end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -2,6 +2,7 @@ class Project < ApplicationRecord
   belongs_to :active_mock_profile, class_name: 'MockProfile', foreign_key: 'mock_profile_id'
 
   has_one :proxy_configuration
+  has_one :api_gateway_integration
 
   has_many :resources, inverse_of: :project, dependent: :destroy
   has_many :resource_representations, through: :resources
@@ -16,6 +17,7 @@ class Project < ApplicationRecord
   has_many :security_schemes, inverse_of: :project, dependent: :destroy
 
   accepts_nested_attributes_for :proxy_configuration, allow_destroy: true
+  accepts_nested_attributes_for :api_gateway_integration, allow_destroy: true
 
   validates :title, presence: true, length: { in: 2..25 }, uniqueness: true
 

--- a/app/policies/project_policy.rb
+++ b/app/policies/project_policy.rb
@@ -51,6 +51,13 @@ class ProjectPolicy < ApplicationPolicy
         :ignore_ssl,
         :_destroy
       ],
+      api_gateway_integration_attributes: [
+        :id,
+        :title,
+        :uri_prefix,
+        :timeout_in_millis,
+        :_destroy
+      ],
       user_ids: []
     ]
   end

--- a/app/views/projects/_api_gateway_integration_fields.html.haml
+++ b/app/views/projects/_api_gateway_integration_fields.html.haml
@@ -1,0 +1,8 @@
+%h3 API Gateway Integration
+
+%p If you do not use API Gateway Integration, keep following fields blank.
+
+.fields.nested-fields
+  = f.text_field :title, placeholder: 'Title replacement or configurable title (eg: "${PROJECT_TITLE}")'
+  = f.text_field :uri_prefix, placeholder: 'Prefix to add to each uri (ex: "http://example.com/context/" or "${PROJECT_URI}")'
+  = f.number_field :timeout_in_millis, placeholder: 29000

--- a/app/views/projects/_form.html.haml
+++ b/app/views/projects/_form.html.haml
@@ -16,3 +16,6 @@
 
   = f.fields_for :proxy_configuration do |fields|
     = render 'proxy_configuration_fields', :f => fields
+
+  = f.fields_for :api_gateway_integration do |fields|
+    = render 'api_gateway_integration_fields', :f => fields

--- a/app/views/projects/show.html.haml
+++ b/app/views/projects/show.html.haml
@@ -48,6 +48,13 @@
     = link_to 'Ruby', project_path(project, format: 'ruby'), class: 'btn btn-primary'
     = link_to 'Typescript', project_path(project, format: 'typescript'), class: 'btn btn-primary'
 
+  %h4 API Gateway Integration
+  .buttons
+    = link_to 'Swagger format',
+      project_path(project, format: 'api_gateway_integration'),
+      class: 'btn btn-primary',
+      data: { confirm: project.resource_representation_name_as_swagger_uid }
+
   - if Rails.application.secrets.slack[:client_id]
     %h4 Slack
     - if project.slack_channel.present?

--- a/app/views/projects/show.html.haml
+++ b/app/views/projects/show.html.haml
@@ -33,6 +33,10 @@
       project_path(project, format: 'swagger'),
       class: 'btn btn-primary',
       data: { confirm: project.resource_representation_name_as_swagger_uid }
+    = link_to 'Swagger with API Gateway integration',
+      project_path(project, format: 'swagger', with_api_gateway_integration: true),
+      class: 'btn btn-primary',
+      data: { confirm: project.resource_representation_name_as_swagger_uid }
 
 
   %p
@@ -47,13 +51,6 @@
     = link_to 'Kotlin', project_path(project, format: 'kotlin'), class: 'btn btn-primary'
     = link_to 'Ruby', project_path(project, format: 'ruby'), class: 'btn btn-primary'
     = link_to 'Typescript', project_path(project, format: 'typescript'), class: 'btn btn-primary'
-
-  %h4 API Gateway Integration
-  .buttons
-    = link_to 'Swagger format',
-      project_path(project, format: 'api_gateway_integration'),
-      class: 'btn btn-primary',
-      data: { confirm: project.resource_representation_name_as_swagger_uid }
 
   - if Rails.application.secrets.slack[:client_id]
     %h4 Slack

--- a/config/initializers/mime_types.rb
+++ b/config/initializers/mime_types.rb
@@ -9,3 +9,4 @@ Mime::Type.register "text/plain", :swift
 Mime::Type.register "text/plain", :ruby
 Mime::Type.register "text/plain", :typescript
 Mime::Type.register "application/x-yaml", :swagger
+Mime::Type.register "application/json", :api_gateway_integration

--- a/config/initializers/mime_types.rb
+++ b/config/initializers/mime_types.rb
@@ -9,4 +9,3 @@ Mime::Type.register "text/plain", :swift
 Mime::Type.register "text/plain", :ruby
 Mime::Type.register "text/plain", :typescript
 Mime::Type.register "application/x-yaml", :swagger
-Mime::Type.register "application/json", :api_gateway_integration

--- a/db/migrate/20190928112108_add_api_gateway_integration.rb
+++ b/db/migrate/20190928112108_add_api_gateway_integration.rb
@@ -1,0 +1,14 @@
+class AddApiGatewayIntegration < ActiveRecord::Migration[5.1]
+  def up
+    create_table :api_gateway_integrations do |t|
+      t.string :title
+      t.string :uri_prefix
+      t.integer :timeout_in_millis
+      t.references :project, foreign_key: true, index: true
+    end
+  end
+
+  def down
+    drop_table :api_gateway_integrations
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190926081509) do
+ActiveRecord::Schema.define(version: 20190928112108) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -38,6 +38,14 @@ ActiveRecord::Schema.define(version: 20190926081509) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["project_id"], name: "index_api_errors_on_project_id"
+  end
+
+  create_table "api_gateway_integrations", force: :cascade do |t|
+    t.string "title"
+    t.string "uri_prefix"
+    t.integer "timeout_in_millis"
+    t.bigint "project_id"
+    t.index ["project_id"], name: "index_api_gateway_integrations_on_project_id"
   end
 
   create_table "attributes", id: :serial, force: :cascade do |t|
@@ -163,8 +171,8 @@ ActiveRecord::Schema.define(version: 20190926081509) do
   end
 
   create_table "metadatum_instances_mock_pickers", id: false, force: :cascade do |t|
-    t.bigint "metadatum_instance_id", null: false
-    t.bigint "mock_picker_id", null: false
+    t.integer "metadatum_instance_id", null: false
+    t.integer "mock_picker_id", null: false
   end
 
   create_table "mock_pickers", id: :serial, force: :cascade do |t|
@@ -205,6 +213,7 @@ ActiveRecord::Schema.define(version: 20190926081509) do
     t.string "slack_incoming_webhook_url"
     t.string "slack_channel"
     t.datetime "slack_updated_at"
+    t.boolean "amazon_apigateway_integration", default: false, null: false
     t.index ["mock_profile_id"], name: "index_projects_on_mock_profile_id"
   end
 
@@ -359,6 +368,7 @@ ActiveRecord::Schema.define(version: 20190926081509) do
   end
 
   add_foreign_key "api_error_instances", "api_errors"
+  add_foreign_key "api_gateway_integrations", "projects"
   add_foreign_key "attributes", "resources"
   add_foreign_key "attributes", "resources", column: "parent_resource_id"
   add_foreign_key "attributes", "schemes"

--- a/test/decorators/swagger/project_decorator_test.rb
+++ b/test/decorators/swagger/project_decorator_test.rb
@@ -9,6 +9,9 @@ module Swagger
       @representation = @resource.resource_representations.first
       @route = create(:route, resource: @resource, request_resource_representation: @representation, security_scheme: @security_scheme)
       @response = create(:response, route: @route, resource_representation: @representation)
+      @route_with_id = create(:route_with_id, resource: @resource, request_resource_representation: @representation, security_scheme: @security_scheme)
+      @response_with_id = create(:response, route: @route_with_id, resource_representation: @representation)
+      @api_gateway_integration = create(:api_gateway_integration, project: @project)
       @decorator = Swagger::ProjectDecorator.new(@project.reload)
     end
 
@@ -39,6 +42,27 @@ module Swagger
           }
       }
       assert_equal generated_security_schemes, expected_security_schemes
+    end
+
+    test 'generated json with api gateway integration contains configured title' do
+      generated_swagger = JSON.parse(@decorator.to_swagger(true))
+      assert_equal generated_swagger['info']['title'], 'api title'
+    end
+
+    test 'generated route json contains valid API Gateway Integration structure' do
+      generated_x_amazon_apigateway_integration = JSON.parse(@decorator.to_swagger(true))['paths']['/users/:id']['get']['x-amazon-apigateway-integration']
+      expected_x_amazon_apigateway_integration = {
+        'cacheKeyParameters' => ['integration.request.path.id'],
+        'httpMethod' => 'GET',
+        'passthroughBehavior' => 'when_no_match',
+        'requestParameters' => {
+          'integration.request.path.id' => 'method.request.path.id'
+        },
+        'timeoutInMillis' => '29000',
+        'type' => 'http_proxy',
+        'uri' => 'prefix/users/:id'
+      }
+      assert_equal generated_x_amazon_apigateway_integration, expected_x_amazon_apigateway_integration
     end
   end
 end

--- a/test/factories/api_gateway_integrations.rb
+++ b/test/factories/api_gateway_integrations.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :api_gateway_integration do
+    title 'api title'
+    uri_prefix 'prefix'
+    timeout_in_millis 29000
+    project
+  end
+end

--- a/test/factories/routes.rb
+++ b/test/factories/routes.rb
@@ -8,5 +8,11 @@ FactoryBot.define do
     http_method :GET
     url { generate(:route_url) }
     resource
+
+    factory :route_with_id do
+      http_method :GET
+      url '/users/:id'
+      resource
+    end
   end
 end


### PR DESCRIPTION
It is possible to configure Amazon API Gateway with a swagger file.
In some projects, we needed to use this kind of file.
Current swagger file is not enough to do so.

To avoid issues and noises, we do not include those configurations in classical Swagger file.

Also, we needed to be able to configure some parameters (eg: `title`) so the same file would be used in several environments.
We take this opportunity to add specific configuration for this specific file.

This commit does the following:

* Add `api_gateway_integration` in `project`
* Add fields in project form to configure it
* Add a new MIME Type `api_gateway_integration`
* Update `to_swagger` generators to include `api_gateway_integration` or not
* Add a test ensuring the new feature

# QA

<details>
<summary>Edit project form</summary>

![image](https://user-images.githubusercontent.com/11132978/65820652-031a3b80-e22c-11e9-839c-1f32ce7277a1.png)
</details>

<details>
<summary>List of routes</summary>

![image](https://user-images.githubusercontent.com/11132978/65820659-1a592900-e22c-11e9-9203-522e4bf8f783.png)
</details>

<details>
<summary>API Gateway Integration button</summary>

![image](https://user-images.githubusercontent.com/11132978/65820671-3066e980-e22c-11e9-8d5e-34db0eaf74c8.png)
</details>

<details>
<summary>Generated swagger</summary>

```
{"openapi":"3.0.0","info":{"description":"URL\r\n** Please fill URL PROD if it exists or any other urls relative to this project\r\n\r\nFormat\r\n** Specify JSON / Restful format : https://i.imgur.com/rzoYLSX.png\r\n\r\nEncoding\r\n** Define encoding - utf-8 par défaut : https://i.imgur.com/j7pvEy1.png\r\n\r\nCompression\r\n** Define compression : https://i.imgur.com/Eix5nng.png\r\n\r\nProtocol\r\n** Make call with HTTPS (cf. Apple) : https://i.imgur.com/2a6mD2B.png\r\n\r\nLocalization\r\n** Define localization (header preferably or parameter) : https://i.imgur.com/NFDbaiL.png\r\n\r\nDates\r\n** Our date format should fullfill iso 8601 : https://fr.wikipedia.org/wiki/ISO_8601\r\n\r\nAuthentication\r\n** Define the format of the request and the authentication response =\u003e Example: authentication OAuth =\u003e Think to create a route!\r\n** Define errors and associated messages\r\n** Define the headers for each public / private route\r\n** Define the expiration logic of tokens\r\n","title":"${PROJECT_TITLE}","version":"1.0.0"},"servers":[],"tags":[{"name":"Report"}],"paths":{"/reports":{"get":{"tags":["Report"],"x-amazon-apigateway-integration":{"cacheKeyParameters":[],"httpMethod":"GET","passthroughBehavior":"when_no_match","requestParameters":{},"timeoutInMillis":29000,"type":"http_proxy","uri":"${PROJECT_URI}/reports"}}},"/reports/:id":{"get":{"tags":["Report"],"x-amazon-apigateway-integration":{"cacheKeyParameters":["integration.request.path.id"],"httpMethod":"GET","passthroughBehavior":"when_no_match","requestParameters":{"integration.request.path.id":"method.request.path.id"},"timeoutInMillis":29000,"type":"http_proxy","uri":"${PROJECT_URI}/reports/:id"}}},"/reports/:id/detail":{"get":{"tags":["Report"],"x-amazon-apigateway-integration":{"cacheKeyParameters":["integration.request.path.id"],"httpMethod":"GET","passthroughBehavior":"when_no_match","requestParameters":{"integration.request.path.id":"method.request.path.id"},"timeoutInMillis":29000,"type":"http_proxy","uri":"${PROJECT_URI}/reports/:id/detail"}}},"/reports/:id/detail/:subid":{"put":{"tags":["Report"],"x-amazon-apigateway-integration":{"cacheKeyParameters":["integration.request.path.id","integration.request.path.subid"],"httpMethod":"PUT","passthroughBehavior":"when_no_match","requestParameters":{"integration.request.path.id":"method.request.path.id","integration.request.path.subid":"method.request.path.subid"},"timeoutInMillis":29000,"type":"http_proxy","uri":"${PROJECT_URI}/reports/:id/detail/:subid"}}}},"components":{"schemas":{"DefaultReport":{"title":"Report - DefaultReport","type":"object","properties":{"id":{"type":"string"},"code":{"type":"string"}},"additionalProperties":false,"description":"Automatically generated (please edit me)","required":["code","id"]}},"securitySchemes":{}}}
```
</details>