### PR TITLE
Add operation id in swagger

### DIFF
--- a/app/decorators/swagger/route_decorator.rb
+++ b/app/decorators/swagger/route_decorator.rb
@@ -5,6 +5,7 @@ class Swagger::RouteDecorator < Draper::Decorator
     {
       tags: [resource.name],
       description: description,
+      operationId: swagger_operation_id,
       parameters: parameters,
       responses: responses,
       requestBody: request_body,
@@ -12,6 +13,20 @@ class Swagger::RouteDecorator < Draper::Decorator
       security: security,
       'x-amazon-apigateway-integration' => x_amazon_apigateway_integration(api_gateway_integration)
     }.select { |_, v| v.present? }
+  end
+
+  def swagger_operation_id
+    return operation_id if operation_id.present?
+
+    result = http_method.downcase
+    url.split('/').map do |part|
+      if part.starts_with?(':')
+        result += "By#{part[1..-1].capitalize}"
+      else
+        result += part.capitalize
+      end
+    end
+    result.delete("^a-zA-Z0-9")
   end
 
   def responses

--- a/app/models/route.rb
+++ b/app/models/route.rb
@@ -21,6 +21,7 @@ class Route < ApplicationRecord
   validates :resource, presence: true, uniqueness: { scope: [:http_method, :url] }
   validate :request_resource_representation_must_belongs_to_project
   validate :security_scheme_must_belongs_to_project
+  validate :operation_id_unique_in_project
 
   audited
   has_associated_audits
@@ -74,5 +75,10 @@ class Route < ApplicationRecord
     return unless security_scheme
     return if security_scheme.project == project
     errors.add(:security_scheme, :security_scheme_must_belongs_to_project)
+  end
+
+  def operation_id_unique_in_project
+    return if operation_id.blank?
+    errors.add(:operation_id, :operation_id_must_be_unique_in_project) if project.routes.where.not(id: id).where(operation_id: operation_id).any?
   end
 end

--- a/app/policies/route_policy.rb
+++ b/app/policies/route_policy.rb
@@ -4,6 +4,7 @@ class RoutePolicy < ProjectRelatedPolicy
       :description,
       :http_method,
       :url,
+      :operation_id,
       :resource_id,
       :security_scheme_id,
       :request_resource_representation_id,

--- a/app/views/routes/_base_form.html.haml
+++ b/app/views/routes/_base_form.html.haml
@@ -1,4 +1,4 @@
-= bootstrap_form_for([project, route]) do |f|
+= bootstrap_form_for([project, route], url: if route.new_record? then nil else "/projects/#{project.id}/routes/#{route.id}?section=base" end) do |f|
   .flexcontainer-justify-end= f.submit class: 'btn btn-primary'
   = render 'shared/errors', object: route
 

--- a/app/views/routes/_base_form.html.haml
+++ b/app/views/routes/_base_form.html.haml
@@ -7,6 +7,7 @@
       = f.select :resource_id, project.resources.collect { |r| [ r.name, r.id ] }, include_blank: false
       = f.text_field :url, placeholder: "/my_resources"
       = f.select :http_method, Route.http_methods.keys.to_a
+      = f.text_field :operation_id, placeholder: "Operation id (unique per project)"
       = f.text_area :description, placeholder: t('.description_placeholder')
       = f.select :security_scheme_id, project.security_schemes.collect { |ss| [ ss.key, ss.id ] }, include_blank: true
       = f.text_field :deprecated, placeholder: "If deprecated, please tell why. Empty field means not deprecated"

--- a/app/views/routes/_base_form.html.haml
+++ b/app/views/routes/_base_form.html.haml
@@ -1,4 +1,4 @@
-= bootstrap_form_for([project, route], url: if route.new_record? then nil else "/projects/#{project.id}/routes/#{route.id}?section=base" end) do |f|
+= bootstrap_form_for([project, route], url: if route.new_record? then nil else project_route_path(project, route, section: :base) end) do |f|
   .flexcontainer-justify-end= f.submit class: 'btn btn-primary'
   = render 'shared/errors', object: route
 

--- a/config/locales/routes/en.yml
+++ b/config/locales/routes/en.yml
@@ -23,3 +23,11 @@ en:
     header_fields:
       name_placeholder: Content-Type
       value_placeholder: application/json
+
+  activerecord:
+    errors:
+      models:
+        route:
+          attributes:
+            operation_id:
+              operation_id_must_be_unique_in_project: The name is already used by another route

--- a/db/migrate/20191101142812_add_operation_id.rb
+++ b/db/migrate/20191101142812_add_operation_id.rb
@@ -1,0 +1,9 @@
+class AddOperationId < ActiveRecord::Migration[5.0]
+  def up
+    add_column :routes, :operation_id, :string
+  end
+
+  def down
+    remove_column :routes, :operation_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20191101093918) do
+ActiveRecord::Schema.define(version: 20191101142812) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -309,8 +309,9 @@ ActiveRecord::Schema.define(version: 20191101093918) do
     t.integer "request_resource_representation_id"
     t.boolean "request_is_collection", default: false, null: false
     t.string "request_root_key"
-    t.bigint "security_scheme_id"
     t.string "deprecated"
+    t.bigint "security_scheme_id"
+    t.string "operation_id"
     t.index ["request_resource_representation_id"], name: "index_routes_on_request_resource_representation_id"
     t.index ["resource_id"], name: "index_routes_on_resource_id"
     t.index ["security_scheme_id"], name: "index_routes_on_security_scheme_id"


### PR DESCRIPTION
Some tools need an operation id to work correctly.
To do so, we add an explicit field in route edition and an implicit generated operation id.

This commit does the following:

* Add `Route.operation_id` in schema
* Add the field into form
* In swagger generation, returns the persisted operation id or generate one with route method and path