### PR TITLE
Correct the datetime format for json schema

### DIFF
--- a/app/decorators/json_schema/attributes_resource_representation_decorator.rb
+++ b/app/decorators/json_schema/attributes_resource_representation_decorator.rb
@@ -54,7 +54,7 @@ module JSONSchema
     def primitive_property
       {
         type: resource_attribute.primitive_type,
-        format: format,
+        format: if format == "datetime" then "date-time" else format end,
         pattern: pattern,
         enum: enum
       }.merge(min_max_constraints)

--- a/app/decorators/json_schema/attributes_resource_representation_decorator.rb
+++ b/app/decorators/json_schema/attributes_resource_representation_decorator.rb
@@ -54,7 +54,7 @@ module JSONSchema
     def primitive_property
       {
         type: resource_attribute.primitive_type,
-        format: if format == "datetime" then "date-time" else format end,
+        format: format == "datetime" ? "date-time" : format,
         pattern: pattern,
         enum: enum
       }.merge(min_max_constraints)

--- a/test/services/json_schema_builder_test.rb
+++ b/test/services/json_schema_builder_test.rb
@@ -111,7 +111,7 @@ class JSONSchemaBuilderTest < ActiveSupport::TestCase
 
   test 'attribute datetime format is datetime' do
     schema = schema_with_one_attribute('keyname', :datetime)
-    assert_equal 'datetime', schema[:properties][:keyname][:format]
+    assert_equal 'date-time', schema[:properties][:keyname][:format]
   end
 
   test 'attribute object is of type object' do


### PR DESCRIPTION
According to the specification, the format of datetime attributes is `date-time`.
It created some issues in tools we used because they do not know the format.

This commit does the following:

* In json schema decorator, transform format `datetime` into `date-time`

See https://json-schema.org/draft/2019-09/json-schema-validation.html#rfc.section.7.3.1